### PR TITLE
Fixed CloudSpec

### DIFF
--- a/test/controllers/CloudSpec.scala
+++ b/test/controllers/CloudSpec.scala
@@ -18,14 +18,14 @@ class CloudSpec extends PlaySpecification with AroundExample with Injectable {
     def applicationModule = new WebModule :: new SilhouetteModule
   }
 
-  implicit val injector = TestGlobal.applicationModule
+  implicit lazy val injector = TestGlobal.injector
 
 
   /**
    * This automatically handles up and down evolutions at the beginning and at the end of a spec respectively
    */
   def around[T: AsResult](t: => T) = {
-    val app = FakeApplication(additionalConfiguration = inMemoryDatabase()++ Map(
+    val app = FakeApplication(withGlobal = Some(TestGlobal), additionalConfiguration = inMemoryDatabase() ++ Map(
       "silhouette.authenticator.sessionKey" -> "livrarium-auth-test",
       "silhouette.authenticator.encryptAuthenticator" -> true,
       "silhouette.authenticator.useFingerprinting" -> true,


### PR DESCRIPTION
Hi, I fixed this test. There were 3 issues:
1. You forgot to provide`TestGlobal` to fake application
2.  The `injector` should be a lazy val (or def) because it depends on the lifecycle of the application and should be accessed lazily (if you want to define it on the test class level)
3. the `applicationModule` method is only there for you to provide your application-specific modules. You should use `injector` in this case, because it represents the final injector aggregation.
