### PR TITLE
Improvements

### DIFF
--- a/app/controllers/Cloud.scala
+++ b/app/controllers/Cloud.scala
@@ -32,6 +32,7 @@ class Cloud(implicit inj: Injector)
   val folderService = inject[FolderService]
   val bookService = inject[BookService]
   val randomIdGenerator = inject[RandomIdGenerator]
+  val applicationPath = inject[play.api.Application].path
 
 
   /**
@@ -137,7 +138,6 @@ class Cloud(implicit inj: Injector)
         val extension = filename.drop(filename.lastIndexOf('.'))
         val uuid = randomIdGenerator.generateBookId()
 
-        val applicationPath = Play.current.path
         val userId = user.id
         val uploadFolder = applicationPath + inject[String](identified by "folders.uploadPath")
         val generatedImageFolder = applicationPath + inject[String](identified by "folders.generatedImagePath")

--- a/app/daos/BookDAO.scala
+++ b/app/daos/BookDAO.scala
@@ -1,8 +1,8 @@
 package daos
 
 import daos.DBTableDefinitions.{BookToFolder, Books, BooksToFolders, DBBook}
-import play.api.Play
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfig}
+import scaldi.{Injector, Injectable}
 import slick.driver.JdbcProfile
 import slick.lifted.TableQuery
 import slick.driver.PostgresDriver.api._
@@ -11,8 +11,8 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 import scala.concurrent.Future
 
-class BookDAO extends HasDatabaseConfig[JdbcProfile] {
-  val dbConfig = DatabaseConfigProvider.get[JdbcProfile](Play.current)
+class BookDAO(implicit inj: Injector) extends HasDatabaseConfig[JdbcProfile] with Injectable {
+  val dbConfig = inject[DatabaseConfigProvider].get[JdbcProfile]
 
   val slickBooks = TableQuery[Books]
   val slickBooksToFolders = TableQuery[BooksToFolders]

--- a/app/daos/FolderDAO.scala
+++ b/app/daos/FolderDAO.scala
@@ -2,7 +2,7 @@ package daos
 
 import daos.DBTableDefinitions.{DBFolder, Folders}
 
-import play.api.Play
+import scaldi.{Injector, Injectable}
 import slick.driver.JdbcProfile
 import play.api.db.slick._
 import slick.driver.PostgresDriver.api._
@@ -12,8 +12,8 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 import scala.concurrent.Future
 
-class FolderDAO extends HasDatabaseConfig[JdbcProfile] {
-  val dbConfig = DatabaseConfigProvider.get[JdbcProfile](Play.current)
+class FolderDAO(implicit inj: Injector) extends HasDatabaseConfig[JdbcProfile] with Injectable {
+  val dbConfig = inject[DatabaseConfigProvider].get[JdbcProfile]
 
 
   val rootFolderName = ""

--- a/app/daos/UserDAO.scala
+++ b/app/daos/UserDAO.scala
@@ -3,7 +3,7 @@ package daos
 import com.mohiva.play.silhouette.api.LoginInfo
 import daos.DBTableDefinitions.{DBUser, LoginInfos, Users}
 
-import play.api.Play
+import scaldi.{Injector, Injectable}
 import slick.driver.JdbcProfile
 import play.api.db.slick._
 import slick.driver.PostgresDriver.api._
@@ -14,8 +14,8 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
 
 
-class UserDAO extends HasDatabaseConfig[JdbcProfile] {
-  val dbConfig = DatabaseConfigProvider.get[JdbcProfile](Play.current)
+class UserDAO(implicit inj: Injector) extends HasDatabaseConfig[JdbcProfile] with Injectable {
+  val dbConfig = inject[DatabaseConfigProvider].get[JdbcProfile]
 
 
   private val slickUsers = TableQuery[Users]

--- a/app/daos/silhouette/LoginInfoDAO.scala
+++ b/app/daos/silhouette/LoginInfoDAO.scala
@@ -2,8 +2,8 @@ package daos.silhouette
 
 import com.mohiva.play.silhouette.api.LoginInfo
 import daos.DBTableDefinitions.{DBLoginInfo, LoginInfos}
-import play.api.Play
 import play.api.db.slick._
+import scaldi.{Injectable, Injector}
 import slick.driver.PostgresDriver.api._
 
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -12,8 +12,8 @@ import slick.driver.JdbcProfile
 import scala.concurrent.Future
 import slick.lifted.TableQuery
 
-class LoginInfoDAO extends HasDatabaseConfig[JdbcProfile] {
-  val dbConfig = DatabaseConfigProvider.get[JdbcProfile](Play.current)
+class LoginInfoDAO(implicit inj: Injector) extends HasDatabaseConfig[JdbcProfile] with Injectable {
+  val dbConfig = inject[DatabaseConfigProvider].get[JdbcProfile]
 
   private val slickLoginInfos = TableQuery[LoginInfos]
 

--- a/app/daos/silhouette/OAuth1InfoDAO.scala
+++ b/app/daos/silhouette/OAuth1InfoDAO.scala
@@ -4,7 +4,7 @@ import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.impl.daos.DelegableAuthInfoDAO
 import com.mohiva.play.silhouette.impl.providers.OAuth1Info
 import daos.DBTableDefinitions.{DBOAuth1Info, LoginInfos, OAuth1Infos}
-import play.api.Play
+import scaldi.{Injectable, Injector}
 import slick.driver.JdbcProfile
 import play.api.db.slick._
 import slick.driver.PostgresDriver.api._
@@ -15,8 +15,8 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
 
 
-class OAuth1InfoDAO extends DelegableAuthInfoDAO[OAuth1Info] with HasDatabaseConfig[JdbcProfile] {
-  val dbConfig = DatabaseConfigProvider.get[JdbcProfile](Play.current)
+class OAuth1InfoDAO(implicit inj: Injector) extends DelegableAuthInfoDAO[OAuth1Info] with HasDatabaseConfig[JdbcProfile] with Injectable {
+  val dbConfig = inject[DatabaseConfigProvider].get[JdbcProfile]
 
 
   private val slickOAuth1Infos = TableQuery[OAuth1Infos]

--- a/app/daos/silhouette/OAuth2InfoDAO.scala
+++ b/app/daos/silhouette/OAuth2InfoDAO.scala
@@ -4,9 +4,9 @@ import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.impl.daos.DelegableAuthInfoDAO
 import com.mohiva.play.silhouette.impl.providers.OAuth2Info
 import daos.DBTableDefinitions.{DBOAuth2Info, LoginInfos, OAuth2Infos}
-import play.api.Play
 import play.api.db.slick._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import scaldi.{Injectable, Injector}
 import slick.driver.JdbcProfile
 import slick.driver.PostgresDriver.api._
 import slick.lifted.TableQuery
@@ -14,8 +14,8 @@ import slick.lifted.TableQuery
 import scala.concurrent.Future
 
 
-class OAuth2InfoDAO extends DelegableAuthInfoDAO[OAuth2Info] with HasDatabaseConfig[JdbcProfile] {
-  val dbConfig = DatabaseConfigProvider.get[JdbcProfile](Play.current)
+class OAuth2InfoDAO(implicit inj: Injector) extends DelegableAuthInfoDAO[OAuth2Info] with HasDatabaseConfig[JdbcProfile] with Injectable {
+  val dbConfig = inject[DatabaseConfigProvider].get[JdbcProfile]
 
 
   private val slickOAuth2Infos = TableQuery[OAuth2Infos]

--- a/app/daos/silhouette/PasswordInfoDAO.scala
+++ b/app/daos/silhouette/PasswordInfoDAO.scala
@@ -4,9 +4,9 @@ import com.mohiva.play.silhouette.api.LoginInfo
 import com.mohiva.play.silhouette.api.util.PasswordInfo
 import com.mohiva.play.silhouette.impl.daos.DelegableAuthInfoDAO
 import daos.DBTableDefinitions.{DBPasswordInfo, LoginInfos, PasswordInfos}
-import play.api.Play
 import play.api.db.slick._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import scaldi.{Injector, Injectable}
 import slick.driver.JdbcProfile
 import slick.driver.PostgresDriver.api._
 import slick.lifted.TableQuery
@@ -14,8 +14,8 @@ import slick.lifted.TableQuery
 import scala.concurrent.Future
 
 
-class PasswordInfoDAO extends DelegableAuthInfoDAO[PasswordInfo] with HasDatabaseConfig[JdbcProfile] {
-  val dbConfig = DatabaseConfigProvider.get[JdbcProfile](Play.current)
+class PasswordInfoDAO(implicit inj: Injector) extends DelegableAuthInfoDAO[PasswordInfo] with HasDatabaseConfig[JdbcProfile] with Injectable {
+  val dbConfig = inject[DatabaseConfigProvider].get[JdbcProfile]
 
 
   private val slickPasswordInfos = TableQuery[PasswordInfos]

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
   "org.postgresql" % "postgresql" % "9.3-1102-jdbc4",
   "com.mohiva" %% "play-silhouette" % "3.0.0-RC1",
   "com.mohiva" %% "play-silhouette-testkit" % "3.0.0-RC1" % "test",
-  "org.scaldi" %% "scaldi-play" % "0.5.7",
+  "org.scaldi" %% "scaldi-play" % "0.5.8",
   "com.sksamuel.scrimage" %% "scrimage-core" % "1.4.1",
   "com.sksamuel.scrimage" %% "scrimage-canvas" % "1.4.1",
   "org.bouncycastle" % "bcprov-jdk16" % "1.45",

--- a/test/controllers/ApplicationSpec.scala
+++ b/test/controllers/ApplicationSpec.scala
@@ -5,18 +5,18 @@ import com.mohiva.play.silhouette.test._
 import fixtures.UserFixture
 import helpers.LivrariumSpecification
 import org.specs2.matcher.ThrownMessages
-import org.specs2.specification.AroundEach
 import play.api.test._
+import scaldi.Injector
 
-class ApplicationSpec extends LivrariumSpecification  with AroundEach with ThrownMessages {
+class ApplicationSpec extends LivrariumSpecification with ThrownMessages {
 
-  protected def bootstrapFixtures(): Unit = {
+  protected def bootstrapFixtures(implicit inj: Injector): Unit = {
     await(UserFixture.initFixture())
   }
 
   "Application controller" should {
 
-    "show login page if user is not authenticated" in {
+    "show login page if user is not authenticated" in { implicit inj: Injector =>
       // Given
       // Authenticated with other user than the one which is stored in current environment
       val request = FakeRequest().withAuthenticator[SessionAuthenticator](UserFixture.otherUserLoginInfo)
@@ -34,7 +34,7 @@ class ApplicationSpec extends LivrariumSpecification  with AroundEach with Throw
       contentAsString(result) must beEqualTo(expectedHtml)
     }
 
-    "show redirect to Cloud index page if user is authenticated" in {
+    "show redirect to Cloud index page if user is authenticated" in { implicit inj: Injector =>
       // Given
       val request = FakeRequest().withAuthenticator[SessionAuthenticator](UserFixture.testUserLoginInfo)
 

--- a/test/daos/BookDAOSpec.scala
+++ b/test/daos/BookDAOSpec.scala
@@ -4,18 +4,18 @@ import daos.DBTableDefinitions.DBBook
 import fixtures.{BookFixture, FolderFixture, UserFixture}
 import helpers.{BookFormatHelper, LivrariumSpecification, RandomIdGenerator}
 import org.specs2.matcher.ThrownMessages
-import org.specs2.specification.AroundEach
+import scaldi.Injector
 
-class BookDAOSpec extends LivrariumSpecification with AroundEach with ThrownMessages {
+class BookDAOSpec extends LivrariumSpecification with ThrownMessages {
 
-  protected def bootstrapFixtures(): Unit = {
+  protected def bootstrapFixtures(implicit inj: Injector): Unit = {
     await(UserFixture.initFixture())
     await(FolderFixture.initFixture())
     await(BookFixture.initFixture())
   }
 
   "Book DAO" should {
-    "insert a book" in {
+    "insert a book" in { implicit inj: Injector =>
       skipped("")
       // Given
       val bookDAO = new BookDAO
@@ -37,7 +37,7 @@ class BookDAOSpec extends LivrariumSpecification with AroundEach with ThrownMess
       testBook.format must beEqualTo(BookFormatHelper.PDF)
     }
 
-    def generateTestBook(): DBBook = {
+    def generateTestBook()(implicit inj: Injector): DBBook = {
       val randomIdGenerator = inject[RandomIdGenerator]
       val generatedBookId = randomIdGenerator.generateBookId() // it generates the same id each time due to the injection
 
@@ -50,7 +50,7 @@ class BookDAOSpec extends LivrariumSpecification with AroundEach with ThrownMess
       )
     }
 
-    "update book if it already exists" in {
+    "update book if it already exists" in { implicit inj: Injector =>
       skipped("")
       // Given
       val bookDAO = new BookDAO
@@ -70,7 +70,7 @@ class BookDAOSpec extends LivrariumSpecification with AroundEach with ThrownMess
       testBook.name must beEqualTo(updatedName)
     }
 
-    "relate book to a folder" in {
+    "relate book to a folder" in { implicit inj: Injector =>
       skipped("")
       // Given
       val bookDAO = new BookDAO

--- a/test/daos/FolderDAOSpec.scala
+++ b/test/daos/FolderDAOSpec.scala
@@ -3,17 +3,17 @@ package daos
 import fixtures.{FolderFixture, UserFixture}
 import helpers.LivrariumSpecification
 import org.specs2.matcher.ThrownMessages
-import org.specs2.specification.{AroundEach, AroundExample}
+import scaldi.Injector
 
-class FolderDAOSpec extends LivrariumSpecification with AroundEach with ThrownMessages {
+class FolderDAOSpec extends LivrariumSpecification with ThrownMessages {
 
-  protected def bootstrapFixtures(): Unit = {
+  protected def bootstrapFixtures(implicit inj: Injector): Unit = {
     await(UserFixture.initFixture())
     await(FolderFixture.initFixture())
   }
 
   "Folder DAO" should {
-    "find folder's children" in {
+    "find folder's children" in { implicit inj: Injector =>
       // Given
       val folderDAO = new FolderDAO
 
@@ -26,7 +26,7 @@ class FolderDAOSpec extends LivrariumSpecification with AroundEach with ThrownMe
       rootFolderChildren(1).name must beEqualTo(FolderFixture.sub2Name)
     }
 
-    "find folder by id" in {
+    "find folder by id" in { implicit inj: Injector =>
       // Given
       val folderDAO = new FolderDAO
 
@@ -37,7 +37,7 @@ class FolderDAOSpec extends LivrariumSpecification with AroundEach with ThrownMe
       folder.name must beEqualTo(FolderFixture.sub1Name)
     }
 
-    "affect correct level to appended folder" in {
+    "affect correct level to appended folder" in { implicit inj: Injector =>
       // Given
       val folderDAO = new FolderDAO
 

--- a/test/daos/LoginInfoDAOSpec.scala
+++ b/test/daos/LoginInfoDAOSpec.scala
@@ -5,17 +5,16 @@ import daos.silhouette.LoginInfoDAO
 import fixtures.UserFixture
 import helpers.LivrariumSpecification
 import org.specs2.matcher.ThrownMessages
-import org.specs2.specification.AroundEach
+import scaldi.Injector
 
-class LoginInfoDAOSpec extends LivrariumSpecification with AroundEach with ThrownMessages {
+class LoginInfoDAOSpec extends LivrariumSpecification with ThrownMessages {
 
-  protected def bootstrapFixtures(): Unit = {
+  protected def bootstrapFixtures(implicit inj: Injector): Unit = {
     await(UserFixture.initFixture())
   }
 
   "LoginInfo DAO" should {
-    "find login info if it exists" in {
-      println("SPEC1")
+    "find login info if it exists" in { implicit inj: Injector =>
       // Given
       val loginInfoDAO = new LoginInfoDAO
 
@@ -26,8 +25,7 @@ class LoginInfoDAOSpec extends LivrariumSpecification with AroundEach with Throw
       foundLoginInfo must beSome
     }
 
-    "find None if login info does not exist" in {
-      println("SPEC2")
+    "find None if login info does not exist" in { implicit inj: Injector =>
       // Given
       val loginInfoDAO = new LoginInfoDAO
 
@@ -40,8 +38,7 @@ class LoginInfoDAOSpec extends LivrariumSpecification with AroundEach with Throw
       foundLoginInfo must beNone
     }
 
-    "insert new LoginInfo" in {
-      println("SPEC3")
+    "insert new LoginInfo" in { implicit inj: Injector =>
       // Given
       val loginInfoDAO = new LoginInfoDAO
 

--- a/test/daos/UserDAOSpec.scala
+++ b/test/daos/UserDAOSpec.scala
@@ -4,16 +4,16 @@ import daos.DBTableDefinitions.DBUser
 import fixtures.UserFixture
 import helpers.LivrariumSpecification
 import org.specs2.matcher.ThrownMessages
-import org.specs2.specification.AroundEach
+import scaldi.Injector
 
-class UserDAOSpec extends LivrariumSpecification with AroundEach with ThrownMessages {
+class UserDAOSpec extends LivrariumSpecification with ThrownMessages {
 
-  protected def bootstrapFixtures(): Unit = {
+  protected def bootstrapFixtures(implicit inj: Injector): Unit = {
     await(UserFixture.initFixture())
   }
 
   "User DAO" should {
-    "find user by its id" in {
+    "find user by its id" in { implicit inj: Injector =>
       // Given
       val userDAO = new UserDAO
 
@@ -26,7 +26,7 @@ class UserDAOSpec extends LivrariumSpecification with AroundEach with ThrownMess
       user.avatarURL must beEqualTo(UserFixture.testUser.avatarURL)
     }
 
-    "find user by its Login Info" in {
+    "find user by its Login Info" in { implicit inj: Injector =>
       // Given
       val userDAO = new UserDAO
 
@@ -39,7 +39,7 @@ class UserDAOSpec extends LivrariumSpecification with AroundEach with ThrownMess
       user.avatarURL must beEqualTo(UserFixture.testUser.avatarURL)
     }
 
-    "insert new user" in {
+    "insert new user" in { implicit inj: Injector =>
       // Given
       val userDAO = new UserDAO
 
@@ -57,7 +57,7 @@ class UserDAOSpec extends LivrariumSpecification with AroundEach with ThrownMess
       foundUser.avatarURL must beEqualTo(newAvatarUrl)
     }
 
-    "update a user" in {
+    "update a user" in { implicit inj: Injector =>
       // Given
       val userDAO = new UserDAO
 

--- a/test/services/FolderServiceSpec.scala
+++ b/test/services/FolderServiceSpec.scala
@@ -3,19 +3,19 @@ package services
 import fixtures.{FolderFixture, UserFixture}
 import helpers.LivrariumSpecification
 import org.specs2.matcher.ThrownMessages
-import org.specs2.specification.AroundEach
+import scaldi.Injector
 
 
-class FolderServiceSpec extends LivrariumSpecification with AroundEach with ThrownMessages {
+class FolderServiceSpec extends LivrariumSpecification with ThrownMessages {
 
-  protected def bootstrapFixtures(): Unit = {
+  protected def bootstrapFixtures(implicit inj: Injector): Unit = {
     await(UserFixture.initFixture())
     await(FolderFixture.initFixture())
   }
 
   "Folder service" should {
 
-    "return user's folder tree" in {
+    "return user's folder tree" in { implicit inj: Injector =>
       // Given
       val folderService = new FolderService
 
@@ -42,7 +42,7 @@ class FolderServiceSpec extends LivrariumSpecification with AroundEach with Thro
       sub2.children must have size 0
     }
 
-    "append a folder to root" in {
+    "append a folder to root" in { implicit inj: Injector =>
       // Given
       val folderService = new FolderService
       val testFolderName = "testFolder"
@@ -58,7 +58,7 @@ class FolderServiceSpec extends LivrariumSpecification with AroundEach with Thro
       testFolder.name must beEqualTo(testFolderName)
     }
 
-    "retrieve folder's children" in {
+    "retrieve folder's children" in { implicit inj: Injector =>
       // Given
       val folderService = new FolderService
 
@@ -75,7 +75,7 @@ class FolderServiceSpec extends LivrariumSpecification with AroundEach with Thro
       subSub2.name must beEqualTo(FolderFixture.sub1sub2Name)
     }
 
-    "append a folder to another folder (not root)" in {
+    "append a folder to another folder (not root)" in { implicit inj: Injector =>
       // Given
       val folderService = new FolderService
       val testFolderName = "testFolder"
@@ -91,7 +91,7 @@ class FolderServiceSpec extends LivrariumSpecification with AroundEach with Thro
       testFolder.name must beEqualTo(testFolderName)
     }
 
-    "retrieve folder by id" in {
+    "retrieve folder by id" in { implicit inj: Injector =>
       // Given
       val folderService = new FolderService
 
@@ -103,7 +103,7 @@ class FolderServiceSpec extends LivrariumSpecification with AroundEach with Thro
       folder.get.name must beEqualTo(FolderFixture.sub1Name)
     }
 
-    "not retrieve another user's folder" in {
+    "not retrieve another user's folder" in { implicit inj: Injector =>
       // Given
       val folderService = new FolderService
 

--- a/test/services/UserServiceSpec.scala
+++ b/test/services/UserServiceSpec.scala
@@ -5,16 +5,16 @@ import daos.silhouette.LoginInfoDAO
 import fixtures.UserFixture
 import helpers.LivrariumSpecification
 import org.specs2.matcher.ThrownMessages
-import org.specs2.specification.AroundEach
+import scaldi.Injector
 
-class UserServiceSpec extends LivrariumSpecification with AroundEach with ThrownMessages {
+class UserServiceSpec extends LivrariumSpecification with ThrownMessages {
 
-  protected def bootstrapFixtures(): Unit = {
+  protected def bootstrapFixtures(implicit inj: Injector): Unit = {
     await(UserFixture.initFixture())
   }
 
   "User service" should {
-    "retrieve user by login info" in {
+    "retrieve user by login info" in { implicit inj: Injector =>
       // Given
       val userService = new UserService
 
@@ -26,7 +26,7 @@ class UserServiceSpec extends LivrariumSpecification with AroundEach with Thrown
       user.avatarURL must beEqualTo(UserFixture.testUser.avatarURL)
     }
 
-    "save a new user" in {
+    "save a new user" in { implicit inj: Injector =>
       // Given
       val userService = new UserService
       val newEmail = "new email"
@@ -42,7 +42,7 @@ class UserServiceSpec extends LivrariumSpecification with AroundEach with Thrown
       user.avatarURL must beEqualTo(newAvatarUrl)
     }
 
-    "not create a new login info if it already exists" in {
+    "not create a new login info if it already exists" in { implicit inj: Injector =>
       // Given
       val userService = new UserService
       val loginInfoDAO = inject[LoginInfoDAO]
@@ -58,7 +58,7 @@ class UserServiceSpec extends LivrariumSpecification with AroundEach with Thrown
       loginInfoCountAfter must beEqualTo(loginInfoCountBefore)
     }
 
-    "create new login info attached to the user if the login info does not exist" in {
+    "create new login info attached to the user if the login info does not exist" in { implicit inj: Injector =>
       // Given
       val userService = new UserService
       val loginInfoDAO = inject[LoginInfoDAO]
@@ -74,7 +74,7 @@ class UserServiceSpec extends LivrariumSpecification with AroundEach with Thrown
       loginInfo must beSome
     }
 
-    "save an already created user" in {
+    "save an already created user" in { implicit inj: Injector =>
       // Given
       val userService = new UserService
 


### PR DESCRIPTION
Summary of the changes:
- Application-specific injector is now used with `ForEach` specs2 fixture
- Manually calling evaluation cleanup now
- Removed usage of `Play.current` and replaced it with DI

Looks like the "down" migration are only performed if the evolution script is changed. Even in official play docs:

https://www.playframework.com/documentation/2.4.x/ScalaTestingWithDatabases

They recommend to do it like this:

```
Evolutions.cleanupEvolutions(database)
```

so I added it and it works. I saw, that you changed the way slick migrations are done recently. Maybe this is a reason for  the change in tests' behavior.

I also did some small improvements along the way :) (hope it is ok for you). I noticed, that you defined `LivrariumSpecification.injector`, even though you used `withScaldiApp` which already creates an injector (and play application) for every single test scenario. In order to reflect this and make application-specific injector available in all of the tests I refactored all tests a little bit and provided them with this injector.

Hope this helps.
